### PR TITLE
カラーアイコンを追加

### DIFF
--- a/style.json
+++ b/style.json
@@ -4873,14 +4873,17 @@
           6
         ],
         [
-          "==",
-          "class",
-          "primary"
-        ],
-        [
-          "==",
-          "class",
-          "secondary"
+          "any",
+          [
+            "==",
+            "class",
+            "primary"
+          ],
+          [
+            "==",
+            "class",
+            "secondary"
+          ]
         ],
         [
           "!=",
@@ -4907,11 +4910,11 @@
         "symbol-spacing": 500,
         "text-field": "{ref}",
         "text-font": [
-          "Noto Sans Regular"
+          "Noto Sans CJK JP Bold"
         ],
         "text-offset": [
           0,
-          0
+          -0.1
         ],
         "text-rotation-alignment": "viewport",
         "text-size": 10,
@@ -4933,7 +4936,7 @@
         [
           "<=",
           "ref_length",
-          6
+          3
         ],
         [
           "==",
@@ -4965,11 +4968,11 @@
         "symbol-spacing": 500,
         "text-field": "{ref}",
         "text-font": [
-          "Noto Sans Regular"
+          "Noto Sans CJK JP Bold"
         ],
         "text-offset": [
           0,
-          0
+          -0.1
         ],
         "text-rotation-alignment": "viewport",
         "text-size": 10,
@@ -5023,11 +5026,11 @@
         "symbol-spacing": 500,
         "text-field": "{ref}",
         "text-font": [
-          "Noto Sans Regular"
+          "Noto Sans CJK JP Bold"
         ],
         "text-offset": [
           0,
-          0
+          -0.1
         ],
         "text-rotation-alignment": "viewport",
         "text-size": 10,

--- a/style.json
+++ b/style.json
@@ -4917,7 +4917,9 @@
         "text-size": 10,
         "icon-size": 1
       },
-      "paint": {}
+      "paint": {
+        "text-color": "#ffffff"
+      }
     },
     {
       "id": "road_shield_national",
@@ -4973,7 +4975,9 @@
         "text-size": 10,
         "icon-size": 1
       },
-      "paint": {}
+      "paint": {
+        "text-color": "#ffffff"
+      }
     },
     {
       "id": "road_shield_highway",
@@ -5029,7 +5033,9 @@
         "text-size": 10,
         "icon-size": 1
       },
-      "paint": {}
+      "paint": {
+        "text-color": "#ffffff"
+      }
     },
     {
       "id": "airport-label-major",

--- a/style.json
+++ b/style.json
@@ -17,7 +17,7 @@
       "url": "https://tileserver.geolonia.com/v2/tiles.json?key=YOUR-API-KEY"
     }
   },
-  "sprite": "https://sprites.geolonia.com/basic",
+  "sprite": "https://raw.githubusercontent.com/geolonia/sprites.geolonia.com/add-road-jp/public/basic-color",
   "glyphs": "https://glyphs.geolonia.com/{fontstack}/{range}.pbf",
   "layers": [
     {
@@ -4859,7 +4859,7 @@
       }
     },
     {
-      "id": "road_shield",
+      "id": "road_shield_prefectural",
       "type": "symbol",
       "metadata": {},
       "source": "geolonia",
@@ -4873,13 +4873,135 @@
           6
         ],
         [
+          "==",
+          "class",
+          "primary"
+        ],
+        [
+          "==",
+          "class",
+          "secondary"
+        ],
+        [
           "!=",
           "disputed",
           "japan_northern_territories"
         ]
       ],
       "layout": {
-        "icon-image": "default_{ref_length}",
+        "icon-image": "prefectural-JP_{ref_length}",
+        "icon-rotation-alignment": "viewport",
+        "symbol-placement": {
+          "base": 1,
+          "stops": [
+            [
+              10,
+              "point"
+            ],
+            [
+              11,
+              "line"
+            ]
+          ]
+        },
+        "symbol-spacing": 500,
+        "text-field": "{ref}",
+        "text-font": [
+          "Noto Sans Regular"
+        ],
+        "text-offset": [
+          0,
+          0
+        ],
+        "text-rotation-alignment": "viewport",
+        "text-size": 10,
+        "icon-size": 1
+      },
+      "paint": {}
+    },
+    {
+      "id": "road_shield_national",
+      "type": "symbol",
+      "metadata": {},
+      "source": "geolonia",
+      "source-layer": "transportation_name",
+      "minzoom": 7,
+      "filter": [
+        "all",
+        [
+          "<=",
+          "ref_length",
+          6
+        ],
+        [
+          "==",
+          "class",
+          "trunk"
+        ],
+        [
+          "!=",
+          "disputed",
+          "japan_northern_territories"
+        ]
+      ],
+      "layout": {
+        "icon-image": "national-JP_{ref_length}",
+        "icon-rotation-alignment": "viewport",
+        "symbol-placement": {
+          "base": 1,
+          "stops": [
+            [
+              10,
+              "point"
+            ],
+            [
+              11,
+              "line"
+            ]
+          ]
+        },
+        "symbol-spacing": 500,
+        "text-field": "{ref}",
+        "text-font": [
+          "Noto Sans Regular"
+        ],
+        "text-offset": [
+          0,
+          0
+        ],
+        "text-rotation-alignment": "viewport",
+        "text-size": 10,
+        "icon-size": 1
+      },
+      "paint": {}
+    },
+    {
+      "id": "road_shield_highway",
+      "type": "symbol",
+      "metadata": {},
+      "source": "geolonia",
+      "source-layer": "transportation_name",
+      "minzoom": 7,
+      "filter": [
+        "all",
+        [
+          "<=",
+          "ref_length",
+          6
+        ],
+        [
+          "==",
+          "class",
+          "motorway"
+        ],
+        [
+          "!=",
+          "disputed",
+          "japan_northern_territories"
+        ]
+      ],
+      "layout": {
+        "icon-image": "highway-JP_{ref_length}",
         "icon-rotation-alignment": "viewport",
         "symbol-placement": {
           "base": 1,

--- a/style.json
+++ b/style.json
@@ -17,7 +17,7 @@
       "url": "https://tileserver.geolonia.com/v2/tiles.json?key=YOUR-API-KEY"
     }
   },
-  "sprite": "https://raw.githubusercontent.com/geolonia/sprites.geolonia.com/add-road-jp/public/basic-color",
+  "sprite": "https://sprites.geolonia.com/basic-color",
   "glyphs": "https://glyphs.geolonia.com/{fontstack}/{range}.pbf",
   "layers": [
     {
@@ -4468,6 +4468,17 @@
                 "get",
                 "class"
               ],
+              "-JP-11"
+            ]
+          ],
+          [
+            "image",
+            [
+              "concat",
+              [
+                "get",
+                "class"
+              ],
               "-11"
             ]
           ],
@@ -4540,6 +4551,17 @@
                 "get",
                 "class"
               ],
+              "-JP-11"
+            ]
+          ],
+          [
+            "image",
+            [
+              "concat",
+              [
+                "get",
+                "class"
+              ],
               "-11"
             ]
           ],
@@ -4600,6 +4622,17 @@
         "text-anchor": "top",
         "icon-image": [
           "coalesce",
+          [
+            "image",
+            [
+              "concat",
+              [
+                "get",
+                "class"
+              ],
+              "-JP-11"
+            ]
+          ],
           [
             "image",
             [


### PR DESCRIPTION
- カラーアイコンを追加
プレビューURL
https://deploy-preview-58--style-basic.netlify.app/#14.15/35.67887/139.76548

- 国道、県道、高速道路の標識をカラーアイコンに変更
![スクリーンショット 2021-10-14 11 36 28](https://user-images.githubusercontent.com/8760841/137259005-c048736c-c369-4e00-b834-93ff15a2cbcd.png)
- 学校や銀行、病院等のアイコンを日本デザインのアイコンに変更
![スクリーンショット 2021-10-14 12 08 11](https://user-images.githubusercontent.com/8760841/137259138-627fd9ac-02b7-4344-82bf-cc509c770d74.png)
![スクリーンショット 2021-10-14 11 54 58](https://user-images.githubusercontent.com/8760841/137259159-9779a652-013e-4d22-9ea9-716baa3a8998.png)

![スクリーンショット 2021-10-14 11 36 13](https://user-images.githubusercontent.com/8760841/137259175-41566e83-ccc5-4ad1-8d74-e022e948a575.png)

